### PR TITLE
THX-34939 support java8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Generated files
 bin/
 gen/
+out/
 
 # Gradle files
 .gradle/

--- a/android-gradle-aspectj/build.gradle
+++ b/android-gradle-aspectj/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testCompile gradleApi()
+    testCompile 'com.android.tools.build:gradle:3.0.0'
 }
 
 group = 'com.archinamon'

--- a/android-gradle-aspectj/build.gradle
+++ b/android-gradle-aspectj/build.gradle
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 buildscript {
     ext.kotlin_version = '1.1.51'
 
@@ -39,6 +55,7 @@ dependencies {
     testCompile 'junit:junit:4.10'
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testCompile gradleApi()
 }
 
 group = 'com.archinamon'

--- a/android-gradle-aspectj/build.gradle
+++ b/android-gradle-aspectj/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext.kotlin_version = '1.1.51'
 
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
@@ -21,6 +22,7 @@ project.ext {
 
 dependencies {
     repositories {
+        google()
         jcenter()
         mavenCentral()
         maven { url 'https://maven.google.com' }

--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -12,9 +12,6 @@
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
- *
- *    Note: This is a new license header as previous contributor did
- *    not provide a boilerplate header and copyright.
  */
 
 package com.archinamon.api.transform
@@ -123,7 +120,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
     override fun transform(transformInvocation: TransformInvocation) {
         // bypassing transformer for non-test variant data in ConfigScope.TEST
         if (!verifyBypassInTestScope(transformInvocation.context)) {
-            // TODO: THX-35249 this bypass does not adhere to the "Transformer Contract"
+            // TODO: THX-35246 this bypass does not adhere to the "Transformer Contract"
             // Each transform MUST write out the input it was given.
             // IE. fileA -> Transform -> FileA
             logBypassTransformation()

--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -207,9 +207,6 @@ internal abstract class AspectJTransform(val project: Project, private val polic
 
         val hasAjRt = hasAj || aspectJWeaver.classPath.any { it.name.contains(AJRUNTIME); }
 
-
-        // TODO: if not hasAjRt then STILL output files
-        // IE always output the input that was given
         if (hasAjRt) {
             logWeaverBuildPolicy(policy)
             aspectJWeaver.doWeave()
@@ -222,6 +219,11 @@ internal abstract class AspectJTransform(val project: Project, private val polic
         } else {
             logEnvInvalid()
             logNoAugmentation()
+            // TODO: should we write out the files before throwing exception?
+            // TODO: consider adding flag to continue build without throwing fatal exception
+            throw GradleException("""Thunderhead AspectJ plugin configured, AspectJ runtime not on classpath.
+                | Try clearing gradle cache and build directory.
+                | Check IDE is not in offline mode.""".trimMargin());
         }
     }
 

--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -1,3 +1,22 @@
+/*
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    Note: This is a new license header as previous contributor did
+ *    not provide a boilerplate header and copyright.
+ */
+
 package com.archinamon.api.transform
 
 import com.android.build.api.transform.*

--- a/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -123,7 +123,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
     override fun transform(transformInvocation: TransformInvocation) {
         // bypassing transformer for non-test variant data in ConfigScope.TEST
         if (!verifyBypassInTestScope(transformInvocation.context)) {
-            // TODO: this bypass does not adhere to the "Transformer Contract"
+            // TODO: THX-35249 this bypass does not adhere to the "Transformer Contract"
             // Each transform MUST write out the input it was given.
             // IE. fileA -> Transform -> FileA
             logBypassTransformation()
@@ -165,7 +165,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
 
             input.directoryInputs.forEach { dir ->
                 // NOTE: The java doc for `name` is quoted as being unreliable.
-                // TODO: Is there another handle to check for AJ runtime being present?
+                // TODO: THX-35245 Is there another handle to check for AJ runtime being present?
                 hasAj = hasAj || dir.name.contains(AJRUNTIME)
                 aspectJWeaver.inPath shl dir.file
                 aspectJWeaver.classPath shl dir.file
@@ -173,7 +173,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
             }
             input.jarInputs.forEach { jar ->
                 // NOTE: The java doc for `name` is quoted as being unreliable.
-                // TODO: Is there another handle to check for AJ runtime being present?
+                // TODO: THX-35245 Is there another handle to check for AJ runtime being present?
                 hasAj = hasAj || jar.name.contains(AJRUNTIME)
 
                 aspectJWeaver.classPath shl jar.file
@@ -223,7 +223,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
             // TODO: consider adding flag to continue build without throwing fatal exception
             throw GradleException("""Thunderhead AspectJ plugin configured, AspectJ runtime not on classpath.
                 | Try clearing gradle cache and build directory.
-                | Check IDE is not in offline mode.""".trimMargin());
+                | Check IDE is not in offline mode.""".trimMargin())
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     ext.kotlin_version = '1.1.51'
 
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,19 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+/*
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 
 buildscript {
     ext.kotlin_version = '1.1.51'


### PR DESCRIPTION
AspectJ weaving only occurs when the plugin can find the AspectJ Runtime.  The plugin detects the jar's availability by looking for its name in the classpath.

The reason the plugin could not find the aspectj runtime was due to the fact that the Android Java8 Desugar Transformer renamed the jar files during a transform. See [Android Gradle Transform Api](http://google.github.io/android-gradle-dsl/javadoc/current/)

The plugin will now throw a build exception instead of logging that it can't find the aspectj runtime. This will be more informative to consumers.

In addition the plugin will now look at the given [Transform Input](http://google.github.io/android-gradle-dsl/javadoc/current/com/android/build/api/transform/TransformInput.html) name instead of the file's name while processing each incremental input.  This [Qualified Content Name Property](http://google.github.io/android-gradle-dsl/javadoc/current/com/android/build/api/transform/QualifiedContent.html) appears to be the maven/gradle coordinate of the given dependency which allows the plugin to check for the AJ Runtime and perform the weave like usual.

