### PR TITLE
THX-34937 support java8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+### Added Java 8 Support
+
+## [<3.2.0 Repository Changelog](https://github.com/Archinamon/android-gradle-aspectj "Archinamon")

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 [![Download](https://api.bintray.com/packages/thunderheadone/Android/Android-Gradle-AspectJ/images/download.svg) ](https://bintray.com/thunderheadone/Android/Android-Gradle-AspectJ/_latestVersion) 
 
 A Gradle plugin which adds the AspectJ toolchain to an Android build.
-Writing code with the AspectJ language in `.aj` files and/or using java annotations.
+Write code with the AspectJ language in `.aj` files and/or using java annotations.
 
 Supported Android Gradle Plugin Version: `3.0.1`
 
 ## Installation
 1. Update your **top-level** `build.gradle` to include the plugin in the build.
-+ Update the `buildScript` `repositories` to include jcenter if it is not present 
++ Update the `buildscript` `repositories` to include jcenter if it is not present 
 and add a `classpath` dependency on the plugin as shown in the following example:
 ``` groovy
 buildscript {
@@ -163,7 +163,7 @@ This won't affect `unitTest` variants.
 ## ProGuard
 
 Correct tuning will depend on your own usage of aspect classes. 
-Iff you declares inter-type injections you'll have to predict side-effects 
+If you declares inter-type injections you'll have to predict side-effects 
 and define your annotations/interfaces which you inject into java classes/methods/etc. in your proguard config.
 
 Basic rules you'll need to declare for your project:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This won't affect `unitTest` variants.
 ## ProGuard
 
 Correct tuning will depend on your own usage of aspect classes. 
-If you declares inter-type injections you'll have to predict side-effects 
+If you declare inter-type injections you'll have to predict side-effects 
 and define your annotations/interfaces which you inject into java classes/methods/etc. in your proguard config.
 
 Basic rules you'll need to declare for your project:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-1.1.51-blue.svg)](http://kotlinlang.org) 
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Download](https://api.bintray.com/packages/thunderheadone/Android/Android-Gradle-AspectJ/images/download.svg) ](https://bintray.com/thunderheadone/Android/Android-Gradle-AspectJ/_latestVersion) 
+[![Download](https://api.bintray.com/packages/thunderheadone/Android/android-gradle-plugin-aspectj/images/download.svg) ](https://bintray.com/thunderheadone/Android/android-gradle-plugin-aspectj/_latestVersion) 
 
 A Gradle plugin which adds the AspectJ toolchain to an Android build.
 Write code with the AspectJ language in `.aj` files and/or using java annotations.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ and add a `classpath` dependency on the plugin as shown in the following example
 ``` groovy
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -31,9 +31,9 @@ buildscript {
 ``` groovy
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
-        google()
     }
 }
 ```
@@ -41,8 +41,8 @@ allprojects {
 ``` gradle
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -52,9 +52,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
-        google()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,95 +1,76 @@
-# GradleAspectJ-Android
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.1.51-blue.svg)](http://kotlinlang.org) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-AspectJ%20Gradle-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/4578) ![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg) [![](https://jitpack.io/v/Archinamon/GradleAspectJ-Android.svg)](https://jitpack.io/#Archinamon/GradleAspectJ-Android) [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[ ![Download](https://api.bintray.com/packages/archinamon/maven/android-gradle-aspectj/images/download.svg) ](https://bintray.com/archinamon/maven/android-gradle-aspectj/_latestVersion)
+![Thunderhead Android Gradle AspectJ](https://www.thunderhead.com/uploads/2015/07/Thunderhead_LogoIcon_Aubergine.png "Thunderhead")
 
-A Gradle plugin which enables AspectJ for Android builds.
-Supports writing code with AspectJ-lang in `.aj` files and in java-annotation style.
-Full support of Android product flavors and build types.
-Support Kotlin, Groovy, Scala and any other languages that compiles into java bytecode.
+# Thunderhead Android Gradle Plugin for AspectJ
 
-Actual version: `com.archinamon:android-gradle-aspectj:3.2.0`.
-<br />
-Friendly with <a href="https://zeroturnaround.com/software/jrebel-for-android/" target="_blank">jRebel for Android</a>!
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.1.51-blue.svg)](http://kotlinlang.org) 
+[![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Download](https://api.bintray.com/packages/thunderheadone/Android/Android-Gradle-AspectJ/images/download.svg) ](https://bintray.com/thunderheadone/Android/Android-Gradle-AspectJ/_latestVersion) 
 
-This plugin is completely friendly with <a href="https://bitbucket.org/hvisser/android-apt" target="_blank">APT</a> (Android Annotation Processing Tools) and <a href="https://github.com/evant/gradle-retrolambda/" target="_blank">Retrolambda</a> project (but Java 8 not supported in .aj files).
-<a href="https://github.com/excilys/androidannotations" target="_blank">AndroidAnnotations</a>, <a href="https://github.com/square/dagger" target="_blank">Dagger</a> are also supported and works fine.
+A Gradle plugin which adds the AspectJ toolchain to an Android build.
+Writing code with the AspectJ language in `.aj` files and/or using java annotations.
 
-This plugin has many ideas from the others similar projects, but no one of them grants full pack of features like this one.
-Nowdays it has been completely re-written using Transform API.
+Supported Android Gradle Plugin Version: `3.0.1`
 
-Key features
------
-
-Augments Java, Kotlin, Groovy bytecode simultaneously!<br />
-Works with background mechanics of jvm-based languages out-of-box!<br />
-[How to teach Android Studio to understand the AspectJ!](IDE)<br />
-May not work properly for AS 3.0 :(
-
-It is easy to isolate your code with aspect classes, that will be simply injected via cross-point functions, named `advices`, into your core application. The main idea is — code less, do more!
-
-AspectJ-Gradle plugin provides supply of all known JVM-based languages, such as Groovy, Kotlin, etc. That means you can easily write cool stuff which may be inject into any JVM language, not only Java itself! :)
-
-To start from you may look at my <a href="https://github.com/Archinamon/AspectJExampleAndroid" target="_blank">example project</a>. And also you may find useful to look at <a href="https://eclipse.org/aspectj/doc/next/quick5.pdf" target="_blank">reference manual</a> of AspectJ language and simple <a href="https://eclipse.org/aspectj/sample-code.html" target="_blank">code snipets</a>. In case aspectj-native not supported by Android Studio (even with IDE-plugin it's using is complicated), you may write a java-classes with aspectj annotations.
-
-Two simple rules you may consider when writing aspect classes.
-- Do not write aspects outside the `src/$flavor/aspectj` source set! These aj-classes will be excluded from java compiler.
-- Do not try to access aspect classes from java/kotlin/etc. In case java compiler doesn't know anything about aspectj, it will lead to compile errors on javac step.
-
-These rules affects only in case you're writing in native aj-syntax.
-You may write aspects in java-annotation style and being free from these limitations.
-
-Usage
------
-
-First add a maven repo link into your `repositories` block of module build file:
-```groovy
-mavenCentral()
-```
-Don't forget to add `mavenCentral()` due to some dependencies inside AspectJ-gradle module.
-
-Add the plugin to your `buildscript`'s `dependencies` section:
-```groovy
-classpath 'com.archinamon:android-gradle-aspectj:3.2.0'
-```
-
-Apply the `aspectj` plugin:
-```groovy
-apply plugin: 'com.archinamon.aspectj'
-```
-
-Now you can write aspects using annotation style or native (even without IntelliJ IDEA Ultimate edition).
-Let's write simple Application advice:
-```java
-import android.app.Application;
-import android.app.NotificationManager;
-import android.content.Context;
-import android.support.v4.app.NotificationCompat;
-
-aspect AppStartNotifier {
-
-    pointcut postInit(): within(Application+) && execution(* Application+.onCreate());
-
-    after() returning: postInit() {
-        Application app = (Application) thisJoinPoint.getTarget();
-        NotificationManager nmng = (NotificationManager) app.getSystemService(Context.NOTIFICATION_SERVICE);
-        nmng.notify(9999, new NotificationCompat.Builder(app)
-            .setTicker("Hello AspectJ")
-            .setContentTitle("Notification from aspectJ")
-            .setContentText("privileged aspect AppAdvice")
-            .setSmallIcon(R.drawable.ic_launcher)
-            .build());
+## Installation
+1. Update your **top-level** `build.gradle` to include the plugin in the build.
++ Update the `buildScript` `repositories` to include jcenter if it is not present 
+and add a `classpath` dependency on the plugin as shown in the following example:
+``` groovy
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.thunderhead.android:android-gradle-plugin-aspectj:4.0.0'
     }
 }
 ```
++ Update the `allprojects` `repositories` closure to include `mavenCentral` as shown in the following example:
+``` groovy
+allprojects {
+    repositories {
+        jcenter()
+        mavenCentral()
+        google()
+    }
+}
+```
++ Example of the **top-level** `build.gradle` file after integration:
+``` gradle
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.thunderhead.android:android-gradle-plugin-aspectj:4.0.0'
+    }
+}
 
-Tune extension
--------
+allprojects {
+    repositories {
+        jcenter()
+        mavenCentral()
+        google()
+    }
+}
+```
+2. Update your **app-level** `build.gradle` to apply the plugin
++ `apply plugin: 'com.thunderhead.android.aspectj'`
+
+
+Now you can write aspects using the annotation style or native AspectJ-lang AJ Syntax (even without IntelliJ IDEA Ultimate edition).
+
+## Plugin Configuration Options
 
 ```groovy
 aspectj {
     ajc '1.8.12' // default value
 
-    /* @see Ext plugin config **/
+    // @see Ext plugin config
     includeAllJars false // default value
     includeJar 'design', 'support-v4', 'dagger' // default is empty
     excludeJar 'support-v7', 'joda' // default is empty
@@ -114,72 +95,76 @@ aspectj {
 ```
 Note that you may not include all these options!
 
-All the extension parameters are have default values (all of them are described above, except of includeJar/Aspects/ajcArgs options).
-So no need to define them manually.
+All the extension parameters have default values (all of them are described above, except for includeJar/Aspects/ajcArgs options)
+and are not needed to be defined manually.
 
-- `ajc` Allows to define the aspectj runtime jar version manually (1.8.12 current)
-- `extendClasspath` Explicitly controls whether plugin should mutate the classpath with aspectj-runtime itself
++ `ajc` Sets the aspectj runtime jar version manually (1.8.12 current).
++ `extendClasspath` Mutates the classpath with the aspectj-runtime itself if set to true(default).
 
-- `includeAllJars` Explicitly include all available jar-files into -inpath to proceed by AJ-compiler
-- `includeJar` Name filter to include any jar/aar which name or path satisfies the filter
-- `excludeJar` Name filter to exclude any jar/aar which name or path satisfies the filter
-- `includeAspectsFromJar` Name filter to include any jar/aar with compiled binary aspects you wanna affect your project
-- `ajcExtraArgs` Additional parameters for aspectj compiler
++ `includeAllJars` Includes all available jar-files in the -inpath argument provided to the aspectj compiler.
++ `includeJar` Name filter to include any jar/aar which name or path satisfies the filter.
++ `excludeJar` Name filter to exclude any jar/aar which name or path satisfies the filter.
++ `includeAspectsFromJar` Name filter to include any jar/aar with compiled binary aspects you want to be woven into your project.
++ `ajcExtraArgs` Additional parameters to be sent to the aspectj compiler.
 
-- `weaveInfo` Enables printing info messages from Aj compiler
-- `debugInfo` Adds special debug info in aspect's bytecode
-- `addSerialVersionUID` Adds serialVersionUID field for Serializable-implemented aspect classes
-- `noInlineAround` Strict ajc to inline around advice's body into the target methods
-- `ignoreErrors` Prevent compiler from aborting if errors occurrs during processing the sources
++ `weaveInfo` Prints info messages from the aspectj compiler when set to true(default).
++ `debugInfo` Prints debug info in aspect's bytecode when set to true(default false).
++ `addSerialVersionUID` Adds serialVersionUID field for Serializable-implemented aspect classes when set to true(default false).
++ `noInlineAround` Forces the aspectj compiler to inline `around` advice into the target methods when set to true(default false).
++ `ignoreErrors` Allows the compiler to continue if errors occur while processing the sources when set to true(default false).
 
-- `breakOnError` Allows to continue project building when ajc fails or throws any errors
-- `experimental` Enables experimental ajc options: `-XhasMember` and `-Xjoinpoints:synchronization,arrayconstruction`. More details in <a href="https://github.com/Archinamon/GradleAspectJ-Android/issues/18" target="_blank">issue #18</a>
++ `breakOnError` Prevents the build from continuing if the aspectj compiler fails or throws any errors if set to true(default).
++ `experimental` Enables experimental aspectj compiler options: `-XhasMember` and `-Xjoinpoints:synchronization,arrayconstruction`. 
+More details in <a href="https://github.com/Archinamon/GradleAspectJ-Android/issues/18" target="_blank">Base Repository #18</a>.
 
-- `buildTimeLog` Appends a BuildTimeListener to current module that prints time spent for every task in build flow, granularity in millis
++ `buildTimeLog` Appends a BuildTimeListener to the current module that prints the time spent for every task in the build flow.
+ Logged in milliseconds.
 
-- `transformLogFile` Defines name for the log file where all Aj compiler info writes to, new separated for Transformer
-- `compilationLogFile` Defines name for the log file where all Aj compiler info writes to, new separated for CompileTask
++ `transformLogFile` Defines the name for the log file where all aspectj compiler info is written to. 
+Writes out during the transform portion of the build.
++ `compilationLogFile` Defines the name for the log file where all aspectj compiler info is written to.
+Writes out during the CompileTask portion of the build.
 
-Extended plugin config
------------------
+## Extended Plugin Configuration
+
+Apply the extended plugin instead of the default plugin.
 ```groovy
-apply plugin: 'com.archinamon.aspectj-ext'
+apply plugin: 'com.thunderhead.android.aspectj-ext'
 ```
 
-Ext config:
-- allows usage of `includeJar` and `includeAllJars` parameters, with workaround to avoid `Multiple dex files exception`
-- supports `multiDex`
-- supports `Instrumented tests`
+Use this plugin when using the `includeJar` and `includeAllJars` configurations or when working in a multidex application.
++ `InstantRun`(IR) must be switched off (The plugin detects IR status and fails the build if IR is switched on).
 
-Currently it has some limitations:
-- `InstantRun` must be switched off (Plugin detects IR status and fails build if IR will be found).
+## Provider Plugin Configuration
 
-Provider plugin config
------------------
+Apply the provider plugin instead of the default plugin.
 ```groovy
-apply plugin: 'com.archinamon.aspectj-provides'
+apply plugin: 'com.thunderhead.android.aspectj-provides'
 ```
 
-Plugin-provider may be useful for that cases when you need to extract aspect-sources into separate module and include it on demand to that modules where you only need it.
-Therefor this behavior will save you build-time due to bypassing aspectj-transformers in provide-only modules.
+Use this plugin for cases when you need to extract aspect-sources into a separate module and include it on demand to the modules where you need it.
+Therefore this plugin will save build-time due to bypassing the aspectj-transformers in provide-only modules.
 
-You ain't limited to describe as much provider-modules as you need and then include them using `includeAspectsFromJar` parameter in the module which code or dependencies you may want to augment.
+You are not limited in the amount of provider modules, you can have as many as you need 
+and then include them using `includeAspectsFromJar` parameter in the module which you want to augment.
 
-With <a href="https://github.com/Archinamon/AspectJExampleAndroid" target="_blank">example project</a> you could learn how to write such provider-module.
 
-Working tests
--------
+## Test Plugin Configuration
+
+Apply the test plugin instead of the default plugin.
 ```groovy
-apply plugin: 'com.archinamon.aspectj-test'
+apply plugin: 'com.thunderhead.android.aspectj-test'
 ```
 
-Test scope configuration inherits `aspectj-ext` behavior with strictly excluding compile and transform tasks from non-test build variant.
+This plugin configuration inherits the `aspectj-ext` behavior with strictly excluding compile and transform tasks from non-test build variants.
 In other words only instrumentation `androidTest` will work with this sub-plugin.
-In case unit tests doesn't really have any specials (excluding source/target code version base) so `aspectj-test` scope won't affect `unitTest` variants.
+This won't affect `unitTest` variants.
 
-ProGuard
--------
-Correct tuning will depends on your own usage of aspect classes. So if you declares inter-type injections you'll have to predict side-effects and define your annotations/interfaces which you inject into java classes/methods/etc. in proguard config.
+## ProGuard
+
+Correct tuning will depend on your own usage of aspect classes. 
+Iff you declares inter-type injections you'll have to predict side-effects 
+and define your annotations/interfaces which you inject into java classes/methods/etc. in your proguard config.
 
 Basic rules you'll need to declare for your project:
 ```
@@ -191,8 +176,9 @@ Basic rules you'll need to declare for your project:
 }
 ```
 
-If you will face problems with lambda factories, you may need to explicitely suppress them. That could happen not in aspect classes but in any arbitrary java-class if you're using Retrolambda.
-So concrete rule is:
+If you face problems with lambda factories, you may need to explicitly suppress them. 
+That could happen not just in aspect classes but in any arbitrary java-class if you're using Retrolambda.
+To avoid this use this concrete rule:
 ```
 -keep class *$Lambda* { <methods>; }
 -keepclassmembernames public class * {
@@ -200,183 +186,10 @@ So concrete rule is:
 }
 ```
 
-Changelog
----------
-#### 3.2.0 -- Gradle 3.0.0 support
-* added support of stable gradle plugin 3.0.0;
-* updated internal ajc and provided aj runtime library versions to the latest 1.8.12;
-
-#### 3.1.1 -- Useful improvements
-* added an extension trigger to append BuildTime logger for current module;
-* back from grave — added exclude-filter for `aspectj-ext` plugin;
-
-#### 3.1.0 -- Provider
-* implemented `provides` plugin split to effectively extract aspects to external/sub modules;
-* small code improvements and cleanups;
-
-#### 3.0.3 -- Minor fixes
-* fixed aar detecting mechanism;
-* registered plugin in mavenCentral!
-
-#### 3.0.0 -- Grand refactoring in Kotlin
-* all groovy classes was obsolete;
-* new code-base in Kotlin 1.1.1 stable;
-
-#### 2.4.3 -- Hot-fixed  two-step compilation
-* compiled in first step aspect classes have not been copied to final output;
-
-#### 2.4.2 -- Hot-fix
-* fixed missed variable;
-* fixed imports;
-
-#### 2.4.0 -- Added aspectj-ext plugin
-* `includeJar` parameter now able to read aar's manifest file to exactly detect required library;
-* `com.archinamon.aspectj-ext` plugin added to properly weave inpath jars, in this mode InstantRun doesn't allowed;
-* small fixes and package/name refactoring;
-
-#### 2.3.1 -- New two-step build mechanic
-* renamed extension parameter: ajcExtraArgs -> ajcArgs;
-* split parameter: logFileName -> [transformLogFile, compilationLogFile];
-* added separate compile task to build all sources under `/aspectj` folder;
-* aj-transformer now looks into `/build/aspectj/$variantName` folder for aspects class';
-* updated ajc-version to 1.8.10;
-* fixed issue with missing error printing to Messages when failing;
-* added inpath/aspectpath clearance before emitting transform inputs (by @philippkumar);
-
-#### 2.3.0 -- Major fixes
-* InstantRun support;
-* fails androidTest hot launch;
-* ZipException within augmenting third party libraries via AspectJ;
-* more clear logging and errors emitting;
-
-#### 2.2.2 -- Improvements
-* fixed build config namings;
-* re-designed work with log file and errors handling;
-* pretty formatting ajc arguments for build stdout;
-* implemented handling custom ajc arguments via build.gradle config;
-
-#### 2.2.1 -- Hot-fix
-* fixed illegal 'return' statement;
-* change included in `updated` 2.2.0 artifacts;
-
-#### 2.2.0 -- Ajc fixes and improvements
-* fixed problem with -aspectPath building project with multidex;
-* fixed scope problems with Transform API;
-* removed Java 8 support;
-* implemented clear and easy way to attach compiled aspects via jar/aar;
-* implemented more easy way to weave by aspects any library (jar/aar);
-* implemented breaking build on errors occurring to prevent runtime issues;
-* implemented ajc experimental features: -XhasMember and -Xjoinpoints:synchronization,arrayconstruction;
-* implemented more logic way to detect the plugin placement in build file to support retrolambda correctly;
-* code cleanups and improvements;
-
-#### 2.1.0 -- Transform api fix
-* finally fixed errors with multidex;
-* fixed jar merge errors;
-* fixed errors with new gradle plugin;
-* fixed Java 8 support;
-* fixed Retrolambda compatibility;
-
-#### 2.0.4 -- Small fix
-* fixed error with mandatory default aj-directory;
-
-#### 2.0.3 -- Gradle instant run
-* merged pull request with the latest gradle plugin update;
-* fixed errors after update;
-
-#### 2.0.2 -- Fixed filters
-* problem with empty filters now fixed;
-
-#### 2.0.1 -- Hotfix :)
-* proper scan of productFlavors and buildTypes folders for aj source sets;
-* more complex selecting aj sources to compile;
-* more precise work with jars;
-* changed jar filter policy;
-* optimized weave flags;
-
-#### 2.0.0 -- Brand new mechanics
-* full refactor on Transform API;
-* added new options to aspectj-extension;
-
-#### 1.3.3 -- Rt qualifier
-* added external runtime version qualifier;
-
-#### 1.3.2 -- One more fix
-* now correctly sets destinationDir;
-
-#### 1.3.1 -- Hot-fixes
-* changed module name from `AspectJ-gradle` to `android-gradle-aspectj`;
-* fixed couple of problems with test flavours processing;
-* added experimental option: `weaveTests`;
-* added finally post-compile processing for tests;
-
-#### 1.3.0 -- Merging binary processing and tests
-* enables binary processing for test flavours;
-* properly aspectpath and after-compile source processing for test flavours;
-* corresponding sources processing between application modules;
-
-#### 1.2.1 -- Hot-fix of Gradle DSL
-* removed unnecessary parameters from aspectj-extension class;
-* fixed gradle dsl-model;
-
-#### 1.2.0 -- Binary weaving
-* plugin now supports processing .class files;
-* supporting jvm languages — Kotlin, Groovy, Scala;
-* updated internal aj-tools and aj runtime to the newest 1.8.9;
-
-#### 1.1.4 -- Experimenting with binary weaving
-* implementing processing aars/jars;
-* added excluding of aj-source folders to avoid aspects re-compiling;
-
-#### 1.1.2 -- Gradle Instant-run
-* now supports gradle-2.0.0-beta plugin and friendly with slicer task;
-* fixed errors within collecting source folders;
-* fixed mixing buildTypes source sets;
-
-#### 1.1.1 -- Updating kernel
-* AspectJ-runtime module has been updated to the newest 1.8.8 version;
-* fixed plugin test;
-
-#### 1.1.0 -- Refactoring
-* includes all previous progress;
-* updated aspectjtools and aspectjrt to 1.8.7 version;
-* now has extension configuration;
-* all logging moved to the separate file in `app/build/ajc_details.log`;
-* logging, log file name, error ignoring now could be tuned within the extension;
-* more complex and correct way to detect and inject source sets for flavors, buildTypes, etc;
-
-#### 1.0.17 -- Cleanup
-* !!IMPORTANT!! now corectly supports automatically indexing and attaching aspectj sources within any buildTypes and flavors;
-* workspace code refactored;
-* removed unnecessary logging calls;
-* optimized ajc logging to provide more info about ongoing compilation;
-
-#### 1.0.16 -- New plugin routes
-* migrating from corp to personal routes within plugin name, classpath;
-
-#### 1.0.15 -- Full flavor support
-* added full support of buld variants within flavors and dimensions;
-* added custom source root folder -- e.g. `src/main/aspectj/path.to.package.Aspect.aj`;
-
-#### 1.0.9 -- Basic flavors support
-* added basic support of additional build varians and flavors;
-* trying to add incremental build //was removed due to current implementation of ajc-task;
-
-#### 1.0 -- Initial release
-* configured properly compile-order for gradle-Retrolambda plugin;
-* added roots for preprocessing generated files (needed to support Dagger, etc.);
-* added MultiDex support;
- 
-#### Known limitations
-* You can't speak with sources in aspectj folder due to excluding it from java compiler;
-* Doesn't support gradle-experimental plugin;
-
-All these limits are fighting on and I'll be glad to introduce new build as soon as I solve these problems.
-
-License
--------
+## License
 
     Copyright 2015 Eduard "Archinamon" Matsukov.
+    Copyright 2018 Thunderhead
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Documentation update.

Points to Thunderhead Bintray package for download.

Specifies supported Android Plugin version.

Arrangement and spell/grammar check.  