### PR TITLE
THX-35487 include aspects from jar

### DIFF
--- a/android-gradle-plugin-aspectj/build.gradle
+++ b/android-gradle-plugin-aspectj/build.gradle
@@ -1,4 +1,5 @@
 /*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
  *    Copyright 2018 the original author or authors.
  *    Copyright 2018 Thunderhead
  *
@@ -40,7 +41,9 @@ dependencies {
     implementation aspectj.runtime
     implementation aspectj.tools
 
+    testImplementation testLibraries.assertJ
     testImplementation testLibraries.junit
+    testImplementation testLibraries.mockitoKotlin
     testImplementation jetbrains.kotlinStdLib
     testImplementation jetbrains.kotlinTestJunit
     testImplementation gradleApi()

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/AndroidConfig.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/AndroidConfig.kt
@@ -1,4 +1,5 @@
 /*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
  *    Copyright 2018 the original author or authors.
  *    Copyright 2018 Thunderhead
  *
@@ -23,12 +24,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import java.io.File
 
-const private val ASPECTJ_PLUGIN = "com.archinamon.aspectj"
+private const val ASPECTJ_PLUGIN = "com.archinamon.aspectj"
 const val RETROLAMBDA = "me.tatarka.retrolambda"
 const val MISDEFINITION = "Illegal definition: $ASPECTJ_PLUGIN should be defined after $RETROLAMBDA plugin"
 
-const private val TAG = "AJC:"
-const private val PLUGIN_EXCEPTION = "$TAG You must apply the Android plugin or the Android library plugin"
+private const val TAG = "AJC:"
+private const val PLUGIN_EXCEPTION = "$TAG You must apply the Android plugin or the Android library plugin"
 
 internal class AndroidConfig(val project: Project, val scope: ConfigScope) {
 
@@ -66,9 +67,5 @@ internal class AndroidConfig(val project: Project, val scope: ConfigScope) {
     @Suppress("UNCHECKED_CAST")
     fun getBootClasspath(): List<File> {
         return extAndroid.bootClasspath ?: plugin::class.java.getMethod("getRuntimeJarList").invoke(plugin) as List<File>
-    }
-
-    fun aspectj(): AspectJExtension {
-        return project.extensions.getByType(AspectJExtension::class.java)
     }
 }

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
@@ -36,7 +36,6 @@ import org.gradle.api.tasks.compile.JavaCompile
 import java.io.File
 import java.util.*
 
-// TODO: This task doesn't do incremental builds. Is that problem?
 internal open class AspectJCompileTask : ConventionTask() {
     private var javaCompileDestinationDir: File? = null
     private var classpath: FileCollection? = null
@@ -137,11 +136,11 @@ internal open class AspectJCompileTask : ConventionTask() {
 
         private fun findCompiledAspectsInClasspath(task: AspectJCompileTask, aspectsFromJar: Collection<String>) {
             val classpath = task.classpath
-            if (classpath != null) {
+            if (classpath != null && aspectsFromJar.isNotEmpty()) {
                 val aspects: MutableSet<File> = mutableSetOf()
 
                 classpath.forEach { file ->
-                    if (aspectsFromJar.isNotEmpty() && DependencyFilter.isIncludeFilterMatched(file, aspectsFromJar)) {
+                    if (DependencyFilter.isIncludeFilterMatched(file, aspectsFromJar)) {
                         logJarAspectAdded(file)
                         aspects shl file
                     }

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
@@ -36,7 +36,6 @@ import java.util.*
 
 internal open class AspectJCompileTask : AbstractCompile() {
     var javaCompileDestinationDir: File? = null
-
     internal class Builder(val project: Project) {
 
         private lateinit var plugin: Plugin<Project>
@@ -159,7 +158,10 @@ internal open class AspectJCompileTask : AbstractCompile() {
 
         aspectJWeaver.classPath = LinkedHashSet(classpath.files)
         aspectJWeaver.doWeave()
-        FileUtil.copyDir(destinationDir, javaCompileDestinationDir)
+
+        if (checkJavaEight(project)) {
+            FileUtil.copyDir(destinationDir, javaCompileDestinationDir)
+        }
 
         logCompilationFinish()
     }

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
@@ -22,6 +22,7 @@ import com.archinamon.AspectJExtension
 import com.archinamon.lang.kotlin.closureOf
 import com.archinamon.plugin.ConfigScope
 import com.archinamon.utils.*
+import org.aspectj.util.FileUtil
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -34,6 +35,7 @@ import java.io.File
 import java.util.*
 
 internal open class AspectJCompileTask : AbstractCompile() {
+    var javaCompileDestinationDir: File? = null
 
     internal class Builder(val project: Project) {
 
@@ -81,6 +83,7 @@ internal open class AspectJCompileTask : AbstractCompile() {
             val task = project.task(options, taskName, closureOf<AspectJCompileTask> task@ {
                 destinationDir = obtainBuildDirectory(android)
                 aspectJWeaver = AspectJWeaver(project)
+                javaCompileDestinationDir = javaCompiler.destinationDir
 
                 source(sources)
                 classpath = classpath()
@@ -156,6 +159,7 @@ internal open class AspectJCompileTask : AbstractCompile() {
 
         aspectJWeaver.classPath = LinkedHashSet(classpath.files)
         aspectJWeaver.doWeave()
+        FileUtil.copyDir(destinationDir, javaCompileDestinationDir)
 
         logCompilationFinish()
     }

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/AspectJCompileTask.kt
@@ -20,6 +20,7 @@ package com.archinamon.api
 
 import com.archinamon.AndroidConfig
 import com.archinamon.AspectJExtension
+import com.archinamon.extensions.aspectJExtension
 import com.archinamon.lang.kotlin.closureOf
 import com.archinamon.plugin.ConfigScope
 import com.archinamon.utils.*
@@ -83,7 +84,7 @@ internal open class AspectJCompileTask : ConventionTask() {
                 javaCompileDestinationDir = javaCompiler.destinationDir
 
                 classpath = classpath()
-                findCompiledAspectsInClasspath(this, config.includeAspectsFromJar)
+                findCompiledAspectsInClasspath(this, project.aspectJExtension.includeAspectsFromJar)
 
                 aspectJWeaver.apply {
                     val destination = this@task.destinationDir
@@ -115,7 +116,7 @@ internal open class AspectJCompileTask : ConventionTask() {
             // javaCompile.classpath does not contain exploded-aar/**/jars/*.jars till first run
             javaCompiler.doLast {
                 task.classpath = classpath()
-                findCompiledAspectsInClasspath(task, config.includeAspectsFromJar)
+                findCompiledAspectsInClasspath(task, project.aspectJExtension.includeAspectsFromJar)
             }
 
             //apply behavior

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/api/transform/AspectJTransform.kt
@@ -1,4 +1,5 @@
 /*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
  *    Copyright 2018 the original author or authors.
  *    Copyright 2018 Thunderhead
  *
@@ -26,6 +27,7 @@ import com.android.utils.FileUtils
 import com.archinamon.AndroidConfig
 import com.archinamon.api.AspectJMergeJars
 import com.archinamon.api.AspectJWeaver
+import com.archinamon.extensions.aspectJExtension
 import com.archinamon.plugin.ConfigScope
 import com.archinamon.utils.*
 import com.archinamon.utils.DependencyFilter.isExcludeFilterMatched
@@ -53,7 +55,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
         project.afterEvaluate {
             getVariantDataList(config.plugin).forEach(this::setupVariant)
 
-            with(config.aspectj()) {
+            with(project.aspectJExtension) {
                 aspectJWeaver.weaveInfo = weaveInfo
                 aspectJWeaver.debugInfo = debugInfo
                 aspectJWeaver.addSerialVUID = addSerialVersionUID
@@ -129,9 +131,9 @@ internal abstract class AspectJTransform(val project: Project, private val polic
         }
 
         val outputProvider = transformInvocation.outputProvider
-        val includeJars = config.aspectj().includeJar
-        val excludeJars = config.aspectj().excludeJar
-        val includeAspects = config.aspectj().includeAspectsFromJar
+        val includeJars = project.aspectJExtension.includeJar
+        val excludeJars = project.aspectJExtension.excludeJar
+        val includeAspects = project.aspectJExtension.includeAspectsFromJar
 
         if (!transformInvocation.isIncremental) {
             outputProvider.deleteAll()
@@ -143,16 +145,27 @@ internal abstract class AspectJTransform(val project: Project, private val polic
 
         val inputs = if (modeComplex()) transformInvocation.inputs else transformInvocation.referencedInputs
 
-        if (checkJavaEight(project)) {
+        /*
+         * Only applies to java8 enabled projects:
+         *
+         * Due to Android Gradle Plugin Transformation API not giving us the ability
+         * to configure the desugar tool (either when its run or what it runs on)
+         * we will simply bypass the transformation here by pumping the files out into
+         * the provided output directory.
+         *
+         * In the AspectJCompileTask.kt class we will do the weave and copy the
+         * results into the javac task output so this transformation is not needed.
+         */
+        if (sourceCompatibilityIsJavaEight(project)) {
             inputs.forEach proceedInputs@{ input ->
                 if (input.directoryInputs.isEmpty() && input.jarInputs.isEmpty())
                     return@proceedInputs // if no inputs so nothing to proceed
 
                 input.directoryInputs.forEach { dir ->
                     if (dir.file.isDirectory) {
-                        FileUtils.copyDirectory(dir.file, outputDir);
+                        FileUtils.copyDirectory(dir.file, outputDir)
                     } else {
-                        FileUtils.copyFileToDirectory(dir.file, outputDir);
+                        FileUtils.copyFileToDirectory(dir.file, outputDir)
                     }
                 }
 
@@ -199,7 +212,7 @@ internal abstract class AspectJTransform(val project: Project, private val polic
                 aspectJWeaver.classPath shl jar.file
 
                 if (modeComplex()) {
-                    val includeAllJars = config.aspectj().includeAllJars
+                    val includeAllJars = project.aspectJExtension.includeAllJars
                     val includeFilterMatched = includeJars.isNotEmpty() && isIncludeFilterMatched(jar.file, includeJars)
                     val excludeFilterMatched = excludeJars.isNotEmpty() && isExcludeFilterMatched(jar.file, excludeJars)
 

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/extensions/ProjectExtensions.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/extensions/ProjectExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
+ *    Copyright 2018 the original author or authors.
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.archinamon.extensions
+
+import com.android.build.gradle.*
+import com.archinamon.AspectJExtension
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+
+val Project.androidExtension: TestedExtension
+    get() = when {
+        plugins.hasPlugin(AppPlugin::class.java) -> {
+            extensions.getByType(AppExtension::class.java)
+        }
+        plugins.hasPlugin(LibraryPlugin::class.java) -> {
+            extensions.getByType(LibraryExtension::class.java)
+        }
+        else -> {
+            throw GradleException("""Invalid Android Project Type.
+                |Expected:
+                |${AppPlugin::class.java.name}
+                |or
+                |${LibraryPlugin::class.java.name}""".trimMargin())
+        }
+    }
+
+val Project.aspectJExtension: AspectJExtension
+    get() = extensions.getByType(AspectJExtension::class.java)

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/AspectJWrapper.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/AspectJWrapper.kt
@@ -62,7 +62,7 @@ internal sealed class AspectJWrapper(private val scope: ConfigScope): Plugin<Pro
         }
 
         transformer.withConfig(config).prepareProject()
-        module.registerTransform(transformer)
+//        module.registerTransform(transformer)
     }
 
     internal abstract fun getTransformer(project: Project): AspectJTransform

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/AspectJWrapper.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/AspectJWrapper.kt
@@ -62,7 +62,7 @@ internal sealed class AspectJWrapper(private val scope: ConfigScope): Plugin<Pro
         }
 
         transformer.withConfig(config).prepareProject()
-//        module.registerTransform(transformer)
+        module.registerTransform(transformer)
     }
 
     internal abstract fun getTransformer(project: Project): AspectJTransform

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/PluginSetup.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/PluginSetup.kt
@@ -1,4 +1,5 @@
 /*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
  *    Copyright 2018 the original author or authors.
  *    Copyright 2018 Thunderhead
  *
@@ -17,8 +18,6 @@
 
 package com.archinamon.plugin
 
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.LibraryPlugin
 import com.archinamon.AndroidConfig
 import com.archinamon.AspectJExtension
 import com.archinamon.MISDEFINITION
@@ -28,9 +27,7 @@ import com.archinamon.api.BuildTimeListener
 import com.archinamon.utils.getJavaTask
 import com.archinamon.utils.getVariantDataList
 import org.gradle.api.GradleException
-import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.PluginContainer
 
 internal fun configProject(project: Project, config: AndroidConfig, settings: AspectJExtension) {
     if (settings.extendClasspath) {
@@ -77,7 +74,6 @@ private fun configureCompiler(project: Project, config: AndroidConfig) {
 
         val taskName = "compile${variantName}AspectJ"
         AspectJCompileTask.Builder(project)
-            .plugin(project.plugins.getPlugin(config))
             .config(project.extensions.getByType(AspectJExtension::class.java))
             .compiler(getJavaTask(variant)!!)
             .variant(variant.name)
@@ -96,10 +92,4 @@ private fun checkIfPluginAppliedAfterRetrolambda(project: Project) {
             }
         }
     }
-}
-
-private inline fun <reified T> PluginContainer.getPlugin(config: AndroidConfig): T where T : Plugin<Project> {
-    @Suppress("UNCHECKED_CAST")
-    val plugin: Class<out T> = (if (config.isLibraryPlugin) LibraryPlugin::class.java else AppPlugin::class.java) as Class<T>
-    return getPlugin(plugin)
 }

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/PluginSetup.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/plugin/PluginSetup.kt
@@ -71,6 +71,8 @@ private fun configureCompiler(project: Project, config: AndroidConfig) {
         // do not configure compiler task for non-test variants in ConfigScope.TEST
         if (config.scope == ConfigScope.TEST && !variantName.contains("androidtest", true))
             return@variantScanner
+        if (config.scope == ConfigScope.STANDARD && variantName.contains("androidtest", true))
+            return@variantScanner
 
         val taskName = "compile${variantName}AspectJ"
         AspectJCompileTask.Builder(project)

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/utils/JavaEight.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/utils/JavaEight.kt
@@ -1,22 +1,31 @@
+/*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
+ *    Copyright 2018 the original author or authors.
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 @file:JvmName("JavaEightUtil")
 
 package com.archinamon.utils
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.LibraryPlugin
+import com.archinamon.extensions.androidExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
-fun checkJavaEight(project: Project): Boolean = when {
-    project.plugins.hasPlugin(AppPlugin::class.java) -> {
-        project.extensions.getByType(AppExtension::class.java).compileOptions.sourceCompatibility == JavaVersion.VERSION_1_8
-    }
-    project.plugins.hasPlugin(LibraryPlugin::class.java) -> {
-        project.extensions.getByType(LibraryExtension::class.java).compileOptions.sourceCompatibility == JavaVersion.VERSION_1_8
-    }
-    else -> {
-        false
-    }
-}
+/**
+ * @param [org.gradle.api.Project] The gradle project to check that the plugin is applied to.
+ * @return [Boolean] - True if [com.android.build.gradle.TestedExtension.compileOptions] has sourceCompatibility set to [JavaVersion.VERSION_1_8] .
+ */
+fun sourceCompatibilityIsJavaEight(project: Project): Boolean = project.androidExtension.compileOptions.sourceCompatibility == JavaVersion.VERSION_1_8

--- a/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/utils/JavaEight.kt
+++ b/android-gradle-plugin-aspectj/src/main/kotlin/com/archinamon/utils/JavaEight.kt
@@ -1,0 +1,22 @@
+@file:JvmName("JavaEightUtil")
+
+package com.archinamon.utils
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+
+fun checkJavaEight(project: Project): Boolean = when {
+    project.plugins.hasPlugin(AppPlugin::class.java) -> {
+        project.extensions.getByType(AppExtension::class.java).compileOptions.sourceCompatibility == JavaVersion.VERSION_1_8
+    }
+    project.plugins.hasPlugin(LibraryPlugin::class.java) -> {
+        project.extensions.getByType(LibraryExtension::class.java).compileOptions.sourceCompatibility == JavaVersion.VERSION_1_8
+    }
+    else -> {
+        false
+    }
+}

--- a/android-gradle-plugin-aspectj/src/test/kotlin/com/archinamon/utils/JavaEightUtilTest.kt
+++ b/android-gradle-plugin-aspectj/src/test/kotlin/com/archinamon/utils/JavaEightUtilTest.kt
@@ -1,0 +1,81 @@
+/*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
+ *    Copyright 2018 the original author or authors.
+ *    Copyright 2018 Thunderhead
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.archinamon.utils
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
+import com.android.build.gradle.internal.CompileOptions
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.plugins.PluginContainer
+import org.junit.Test
+
+
+class JavaEightUtilTest {
+    private val mockCompileOptions = mock<CompileOptions>()
+    private val mockAppExtension = mock<AppExtension> {
+        on { compileOptions } doReturn mockCompileOptions
+    }
+    private val mockLibraryExtension = mock<LibraryExtension> {
+        on { compileOptions } doReturn mockCompileOptions
+    }
+    private val mockExtensions = mock<ExtensionContainer> {
+        on { getByType(any<Class<AppExtension>>()) } doReturn mockAppExtension
+        on { getByType(any<Class<LibraryExtension>>()) } doReturn mockLibraryExtension
+    }
+    private val mockPlugins = mock<PluginContainer> {
+        on { hasPlugin(AppPlugin::class.java) } doReturn true
+        on { hasPlugin(LibraryPlugin::class.java) } doReturn true
+    }
+    private val mockProject = mock<Project> {
+        on { plugins } doReturn mockPlugins
+        on { extensions } doReturn mockExtensions
+    }
+
+    @Test
+    fun `test check for java8 source compatibility`() {
+        // Test AppPlugin
+        whenever(mockCompileOptions.sourceCompatibility).thenReturn(JavaVersion.VERSION_1_8)
+        var result = sourceCompatibilityIsJavaEight(mockProject)
+        assertThat(result).isTrue()
+
+        whenever(mockCompileOptions.sourceCompatibility).thenReturn(JavaVersion.VERSION_1_7)
+        result = sourceCompatibilityIsJavaEight(mockProject)
+        assertThat(result).isFalse()
+
+        // Test LibraryPlugin
+        whenever(mockPlugins.hasPlugin(AppPlugin::class.java)).thenReturn(false)
+
+        whenever(mockCompileOptions.sourceCompatibility).thenReturn(JavaVersion.VERSION_1_8)
+        result = sourceCompatibilityIsJavaEight(mockProject)
+        assertThat(result).isTrue()
+
+        whenever(mockCompileOptions.sourceCompatibility).thenReturn(JavaVersion.VERSION_1_7)
+        result = sourceCompatibilityIsJavaEight(mockProject)
+        assertThat(result).isFalse()
+    }
+}

--- a/gradleScripts/dependencies.gradle
+++ b/gradleScripts/dependencies.gradle
@@ -1,4 +1,5 @@
 /*
+ *    Copyright 2015 Eduard "Archinamon" Matsukov.
  *    Copyright 2018 the original author or authors.
  *    Copyright 2018 Thunderhead
  *
@@ -20,6 +21,8 @@ ext {
     kotlin_version = '1.1.51'
     aspectj_version = '1.8.12'
     junit_version = '4.10'
+    assertj_version = '3.11.1'
+    mockito_kotlin_version = '2.0.0'
     gradlePlugins = [
             kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version",
             bintray: 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
@@ -34,7 +37,9 @@ ext {
             tools: "org.aspectj:aspectjtools:$aspectj_version"
     ]
     testLibraries = [
-            junit: "junit:junit:$junit_version"
+            junit: "junit:junit:$junit_version",
+            assertJ: "org.assertj:assertj-core:$assertj_version",
+            mockitoKotlin: "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
     ]
     android = [
             buildTools: 'com.android.tools.build:gradle:3.0.0'


### PR DESCRIPTION
Replace javac output with AJ output when in Java8 Enabled project so the sources are woven before it goes to the transform api and skip the transform all together.  We do this because the transform chain invokes the desugar tool first which messes with the pre compiled aspect byte code constant string pool thus not allowing the transformer to complete the aj weave successfully.  See this [google bug](https://issuetracker.google.com/u/0/issues/119153999)

resolve #5 